### PR TITLE
Changed the event for which greeting workflow runs

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [pull_request, issues]
+on: [pull_request_target, issues]
 
 jobs:
   greeting:
@@ -9,8 +9,8 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: 'Thanks for raising the issue with us. This was your first issue reported in this project. Keep making this product better 🥳'
-        pr-message: 'This was your first contribution in this project. Thanks for making the product better 🥳'
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: "Thanks for raising the issue with us. This was your first issue reported in this project. Keep making this product better 🥳"
+          pr-message: "This was your first contribution in this project. Thanks for making the product better 🥳"


### PR DESCRIPTION
The wok flow now runs on `pull_request_event` rather on `pull_request`.

On pull_request_event
it uses the secrets from the main repo's target branch
rather using it from the contributor's repo..

It was done so that the error which was arising
when a PR was raised from a fork can be averted

Describe about the changes that you made in your PR and also mentioning why it was necessary to do so. If this PR is a reply to any issue, then link the issue here too.

Check to be made before PR

- [ ] Does the code result in any run time error? If yes then describe the error and the steps to reproduce it below.
- [ ] Written tests for the changes you made.
- [ ] Formatted the code with default configuration of `Prettier` code formatter.
