### PR TITLE
docs: Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,6 +21,7 @@ body:
     id: reproduce
     attributes:
       label: Steps to Reproduce
+      description: Step of actions that may cause the bug
       placeholder: |
                   1.
                   2.
@@ -28,7 +29,8 @@ body:
   - type: textarea
     id: context
     attributes:
-      label: Context (Environment)
+      label: Context (Environment) 
+      description: Post Screenshot if possible
       placeholder: Write your environment or anything helpful!
   - type: checkboxes
     id: terms

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: Bug Report
+name: 🐞 Bug Report
 description: File a Bug Report
 title: "[Bug]: ",
 lables: ["bug"]
@@ -9,8 +9,8 @@ body:
       label: Describe the Bug or Error
       description: Also tell us, what did you expect to happen? 
       placeholder: Tell us what you see!
-  validations:
-    required: true
+    validations:
+      required: true
   - type: textarea
     id: logs
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -21,9 +21,10 @@ body:
     id: reproduce
     attributes:
       label: Steps to Reproduce
-      placeholder: 1.
-                   2.
-                   3.
+      placeholder: |
+                  1.
+                  2.
+                  3.
   - type: textarea
     id: context
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: File a Bug Report
 title: "[Bug]: "
-labels: ["bug", "triage"]
+labels: ["bug", "help wanted"]
 body:
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,4 +1,4 @@
-name: 🐞 Bug Report
+name: Bug Report
 description: File a Bug Report
 title: "[Bug]: ",
 lables: ["bug"]

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: 🐞 Bug Report
 description: File a Bug Report
-title: "[Bug]: ",
+title: "[Bug]: "
 lables: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,27 @@
+name: 🐞 Bug Report
+description: File a Bug Report
+title: "[Bug]: ",
+lables: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Describe the Bug or Error
+      description: Also tell us, what did you expect to happen? 
+      placeholder: Tell us what you see!
+  validations:
+    required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -4,19 +4,31 @@ title: "[Bug]: "
 labels: ["bug", "help wanted"]
 body:
   - type: textarea
-    id: what-happened
+    id: expected-behavior
     attributes:
-      label: Describe the Bug or Error
-      description: Also tell us, what did you expect to happen? 
-      placeholder: Tell us what you see!
+      label: Expected Behavior 
+      placeholder: Tell us what you expected
     validations:
       required: true
   - type: textarea
-    id: logs
+    id: current-behavior
     attributes:
-      label: Relevant log output
-      description: Please copy and paste relevant log output. This will be automatically formatted into code, so no need for backticks.
-      render: shell
+      label: Current Behavior
+      placeholder: Tell us what is current output
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to Reproduce
+      placeholder: 1.
+                   2.
+                   3.
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (Environment)
+      placeholder: Write your environment or anything helpful!
   - type: checkboxes
     id: terms
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug Report
 description: File a Bug Report
 title: "[Bug]: "
-lables: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: textarea
     id: what-happened

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,17 +6,16 @@ body:
   - type: textarea
     id: problem
     attributes:
-      label: Describe the current problem
-      description: Provide a clear and concise description of what the problem is 
-      placeholder: Write here...
+      label: Is your proposal related to a problem?  
+      placeholder: Write here
     validations:
       required: true
   - type: textarea
-    id: solution
+    id: proposal
     attributes:
-      label: Describe the solution/feature you'd like
+      label: Describe the feature you'd like
       description: Provide a clear and concise description of what you want to happen
-      placeholder: Describe your proposal solution here...
+      placeholder: Describe your proposal here
     validations:
       required: true  
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,29 @@
+name: 🚀 Feature Request
+description: Suggest an idea for improving hive
+title: "[Feat]: "
+labels: ["enhancement", "help wanted"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the current problem
+      description: Provide a clear and concise description of what the problem is 
+      placeholder: Write here...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution/feature you'd like
+      description: Provide a clear and concise description of what you want to happen
+      placeholder: Describe your proposal solution here...
+    validations:
+      required: true  
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true


### PR DESCRIPTION
This PR closes #31 
Issue templates for `bug-report` and `feature-request`

**Screenshots**:
![1](https://user-images.githubusercontent.com/56498881/152862037-280b81c9-decd-4bd7-9257-284a5d41e281.png)

- `bug-report`

![2](https://user-images.githubusercontent.com/56498881/152862082-a3afd2d5-5cca-428d-bf59-86f768e6cc35.png)

- `feature-request`

![3](https://user-images.githubusercontent.com/56498881/152862369-d8d0bccf-0db0-4064-bf74-7ce184ce2d88.png)

Also, added `.github/ISSUE_TEMPLATE/config.yml` for default issue template options as shown in Screenshot 1

Check to be made before PR
- [x]  Tested the changes I made
- [x] Formatted the code with default configuration of `Prettier` code formatter.
