### PR TITLE
Removing node 12.x from test enviroment

### DIFF
--- a/.github/workflows/Website.yml
+++ b/.github/workflows/Website.yml
@@ -19,7 +19,7 @@ jobs:
         
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
As node 12.x reaches its EOL we will no longer test our code on node 12.x

Describe about the changes that you made in your PR and also mentioning why it was necessary to do so. If this PR is a reply to any issue, then link the issue here too.

Check to be made before PR

- [ ] Does the code result in any run time error? If yes then describe the error and the steps to reproduce it below.
- [ ] Written tests for the changes you made.
- [ ] Formatted the code with default configuration of `Prettier` code formatter.
